### PR TITLE
K8sunified

### DIFF
--- a/3.5.3/Dockerfile
+++ b/3.5.3/Dockerfile
@@ -8,6 +8,10 @@ RUN mkdir -p /opt/liquibase &&\
   mkdir -p /home/rundir &&\
   mkdir /scripts
 
+# Add jq (to validate json)
+ADD https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 /usr/local/bin/jq
+RUN chmod +x /usr/local/bin/jq
+
 # Add liquibase
 ADD http://repo1.maven.org/maven2/org/liquibase/liquibase-core/3.5.3/liquibase-core-3.5.3-bin.tar.gz /opt/liquibase/liquibase-core-bin.tar.gz
 WORKDIR /opt/liquibase

--- a/3.5.3/update.sh
+++ b/3.5.3/update.sh
@@ -5,7 +5,6 @@
 
 ERROR_EXIT_CODE=1
 GIT_BASE="https://raw.githubusercontent.com/yonadev/yona-server/"
-set -x
 
 apply_external_json () {
   SOURCE="${GIT_BASE}build-${RELEASE}/dbinit/data/${1}"

--- a/3.5.3/update.sh
+++ b/3.5.3/update.sh
@@ -1,6 +1,74 @@
 #!/bin/bash
 
+# Note - We are running under K8S as an init job.
+# If we exit non zero we will be rescheduled until success
+
 ERROR_EXIT_CODE=1
+GIT_BASE="https://raw.githubusercontent.com/yonadev/yona-server/"
+set -x
+
+apply_external_json () {
+  SOURCE="${GIT_BASE}build-${RELEASE}/dbinit/data/${1}"
+  TARGET="${2}"
+  DOWNLOAD="${1}"
+  download_validate $DOWNLOAD $SOURCE
+  if [ $? -eq 1 ]; then
+    echo "Failed to download valid json from ${TARGET}"
+    return 1
+  fi
+  upload_validate $DOWNLOAD $TARGET
+  if [ $? -eq 1 ]; then
+    echo "Failed to upload valid json to ${TARGET}"
+    return 1
+  fi
+}
+
+download_validate () {
+  STATUS=$(curl -s -o "/tmp/${1}" -w '%{http_code}' "${2}")
+  if [ $STATUS != "200" ]; then
+    echo "Failed to download ${2} - Error Code ${STATUS}"
+    return 1
+  fi
+  /usr/local/bin/jq . "/tmp/${1}"
+  if [ $? -ne 0 ]; then
+    echo "Download fails json validation ${2}"
+    cat ${2}
+    return 1
+  fi
+}
+
+upload_validate () {
+  STATUS=$(curl -s -o "/tmp/response" -w '%{http_code}' -X PUT "${2}" -d @/tmp/${1} --header "Content-Type: application/json")
+  if [ $STATUS != "200" ]; then
+    echo "Failed to post ${2} - Error Code ${STATUS}"
+    cat /tmp/response
+    return 1
+  fi
+  return 0
+}
+
+liquibase_apply () {
+  echo "Applying changelogs ..."
+  MAX_TRIES=${MAX_TRIES:-1}
+  COUNT=1
+  while [  $COUNT -le $MAX_TRIES ]; do
+     echo  "Attempting to apply changelogs: attempt $COUNT of $MAX_TRIES"
+     liquibase --logLevel=info --changeLogFile=$CHANGE_LOG update
+     if [ $? -eq 0 ];then
+        echo "Changelogs successfully applied"
+        if [ -n "${RELEASE}" ]; then
+          echo "Tagging with ${RELEASE}"
+          liquibase tag ${RELEASE}
+        fi
+        return 0
+     fi
+     echo "Failed to apply changelogs"
+     sleep 2
+     let COUNT=COUNT+1
+  done
+  echo "Too many failed attempts"
+  return 1
+}
 
 echo "Setting up liquibase"
 : ${USER?"USER not set"}
@@ -19,19 +87,38 @@ cat <<CONF > liquibase.properties
   password: $PASSWORD
 CONF
 
-echo "Applying changelogs ..."
-MAX_TRIES=${MAX_TRIES:-1}
-COUNT=1
-while [  $COUNT -le $MAX_TRIES ]; do
-   echo  "Attempting to apply changelogs: attempt $COUNT of $MAX_TRIES"
-   liquibase --logLevel=info --changeLogFile=$CHANGE_LOG update
-   if [ $? -eq 0 ];then
-   	  echo "Changelogs successfully applied"
-      exit 0
-   fi
-   echo "Failed to apply changelogs"
-   sleep 1
-   let COUNT=COUNT+1
-done
-echo "Too many failed attempts"
-exit $ERROR_EXIT_CODE
+#Main 
+
+# Apply Liquibase
+if [ $? -eq 1 ]; then
+  echo "Failed to apply Liquibase Changes - Exiting"
+  exit $ERROR_EXIT_CODE
+fi
+
+if [ -n "${RELEASE}" ]; then
+  # Apply Quartz Jobs
+  echo "Applying Quartz Jobs"
+  apply_external_json "QuartzOtherJobs.json" "http://batch.yona.svc.cluster.local:8080/scheduler/jobs/OTHER/"
+  if [ $? -eq 1 ]; then
+    exit $ERROR_EXIT_CODE
+  fi
+
+  # Apply Quartz Triggers (requires RELEASE env to be set)
+  echo "Applying Quartz Triggers"
+  apply_external_json "QuartzOtherCronTriggers.json" "http://batch.yona.svc.cluster.local:8080/scheduler/triggers/cron/OTHER/"
+  if [ $? -eq 1 ]; then
+    exit $ERROR_EXIT_CODE
+  fi
+
+  # Apply Categories
+  echo "Applying Categories"
+  apply_external_json "productionActivityCategories.json" "http://admin.yona.svc.cluster.local:8080/activityCategories/"
+  if [ $? -eq 1 ]; then
+    exit $ERROR_EXIT_CODE
+  fi
+else
+  echo "RELEASE environment variable not set - Not running JSON updates"
+fi
+
+echo "All updates applied"
+exit 0


### PR DESCRIPTION
Initial refactor to support pushing of the json data for categories and quartz.  Setup with the idea that it can start in tandem with the other containers as a job that will run until success.   Other containers will have an init container just checking for the liquibase release tag.  Will need to create that init container off of this docker, and override the update.sh.

These changes should be safe to continue using with the old platform as all new work is guarded with a check of the RELEASE environment variable that will only be present in the k8s deployments.
